### PR TITLE
Fixes getChrgState

### DIFF
--- a/xadow.cpp
+++ b/xadow.cpp
@@ -86,7 +86,7 @@ unsigned char xadow::getChrgState()
     
     if(!Temp)
     {
-        return NOCHARGE;
+        return CHARGING;
     }
     Temp = DONEpin & DONEbit;
     if(!Temp)

--- a/xadowDfs.h
+++ b/xadowDfs.h
@@ -31,8 +31,8 @@
 #define PINCHRGING          A2
 
 // about charge
-#define CHRGbit 0x10
-#define DONEbit 0x20
+#define CHRGbit _BV(PF5)
+#define DONEbit _BV(PF4)
 #define CHRGdir DDRF
 #define DONEdir DDRF
 #define CHRGpin PINF


### PR DESCRIPTION
This PR fixes `getChrgState`returning incorrect values due to
- Typo in `getChrgState`
- Incorrect pin definitions in `xadowDfs.h`
